### PR TITLE
Fixed The Typography mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     </code>
 </p>
 
-During Google Summer of Code 2022 I worked on the GitHub App for Rocket.Chat. This a GitHub itegration for RocketChat which enables developers to use various GitHub features inside RocketChat channels.
+During Google Summer of Code 2022 I worked on the GitHub App for Rocket.Chat. This a GitHub integration for RocketChat which enables developers to use various GitHub features inside RocketChat channels.
 
 I intend to maintain this repository as a final report summary of my GSoC work and a quick guide for all future GSoC aspirants.
 


### PR DESCRIPTION
In the documentation, there is a typography mistake in the first line of the first paragraph. The spelling mistake of ``Integration`` was misspelled as ``itegration``

